### PR TITLE
Feat: bounce requests with no grow-request-id

### DIFF
--- a/http.ts
+++ b/http.ts
@@ -149,6 +149,9 @@ function handleRequest(cfg: {
   callMethod: CallMethod;
 }) {
   return async (c: Context<any, any, any>) => {
+    if (!c.req.header("grow-request-id")) {
+      return c.json({ error: "Missing request id" }, 400);
+    }
     const args = (await c.req.json()) as any[];
 
     let result;


### PR DESCRIPTION
By design, all requests to grow should have their request ID set so this change should bounce a bunch of invalid requests early enough to minimize DDoS attacks chances.