### PR TITLE
fix: derive call.sessionId/requestId from ctx as fallback

### DIFF
--- a/worker.ts
+++ b/worker.ts
@@ -473,16 +473,19 @@ async function callMethod(
   plant: any,
   call: Call,
 ): Promise<any> {
+  const sessionId = call.sessionId || call.ctx?.sessionId || "";
+  const requestId = call.requestId || call.ctx?.requestId || "";
+
   const plantLogger = getLogger({
     name: `${call.receiver}.${call.method}()`,
-    sessionId: call.sessionId,
-    requestId: call.requestId,
+    sessionId,
+    requestId,
   });
 
   const wrappedPlant = wrapPlant(plant, {
-    sessionId: call.sessionId,
+    sessionId,
     logger: plantLogger,
-    requestId: call.requestId,
+    requestId,
     ctx: call.ctx,
   });
 
@@ -501,8 +504,8 @@ async function callMethod(
 
   if (cacheMeta) {
     const cacheKey = cacheMeta.cacheKey({
-      sessionId: call.sessionId,
-      requestId: call.requestId,
+      sessionId,
+      requestId,
       args: call.args,
     });
 


### PR DESCRIPTION
## Problem

`grow` did not propagate `call.sessionId` / `call.requestId` through inter-service calls that go via `configurableInject` (the typical `cfg => _.set(cfg, "ctx", this.ctx)` pattern). The receiving side saw:

- `this.ctx.sessionId` ✓ (propagated through `cfg.ctx`)
- `call.sessionId` ✗ (`undefined`)

That meant `@cache(..., ctx => ctx.sessionId)` on inter-service-called methods used `undefined` as the key for everyone — collapsing all sessions into a single cache slot. The framework's structured logger (`getLogger({ sessionId, requestId })`) also got `undefined`. This was the live vector behind a session-leak bug observed downstream.

Reproduced log lines:

```
[CACHE] getCurrentUser key= "awadeajf..."   reqId= moirzu...      ← top-level HTTP, OK
[CACHE] SessionAccess.current key= undefined reqId= undefined     ← inter-service, lost
[DEBUG] [SessionAccess.current()] started | sid:undefined rid:undefined
```

## Fix

In `callMethod` (the dispatch point that builds the wrapped plant, the cache key, and the plant logger), fall back to `call.ctx?.sessionId` / `call.ctx?.requestId` when `call.sessionId` / `call.requestId` are not set. This keeps the two layers (plant ctx vs. call metadata) in sync without making every call site set both explicitly.

## Test plan

- [x] `deno task test` — passing (basic_test, main_proc_test)
- [ ] Verify downstream (drzwi) — `SessionAccess.current` cache key is no longer `undefined` for inter-service callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)